### PR TITLE
Build on Linux, tweak command line and section names for GNU as, ld

### DIFF
--- a/platform/linux/i386/_close.htn
+++ b/platform/linux/i386/_close.htn
@@ -1,0 +1,9 @@
+
+_close : (fd : int) -> int {
+   rval : int = -1;
+   __asm__("mov @0, %ebx", fd);
+   __asm__("mov $6, %eax");
+   __asm__("int $0x80");
+   __asm__("mov %eax, @0", rval);
+   return rval;
+}

--- a/platform/linux/i386/_exit.htn
+++ b/platform/linux/i386/_exit.htn
@@ -1,0 +1,7 @@
+
+
+_exit : (rval : int) -> void {
+   __asm__("mov @0, %ebx", rval);
+   __asm__("mov $1, %eax");
+   __asm__("int $0x80");
+}

--- a/platform/linux/i386/_open.htn
+++ b/platform/linux/i386/_open.htn
@@ -1,0 +1,11 @@
+
+_open : (path : *char, flags : int, mode : int) -> int {
+   fd : int = 1;
+   __asm__("mov @0, %ebx", path);
+   __asm__("mov @0, %ecx", flags);
+   __asm__("mov @0, %edx", mode);
+   __asm__("mov $5, %eax");
+   __asm__("int $0x80");
+   __asm__("mov %eax, @0", fd);
+   return fd;
+}

--- a/platform/linux/i386/_write.htn
+++ b/platform/linux/i386/_write.htn
@@ -1,0 +1,12 @@
+
+
+_write : (fd : int, cbuf : *char, nbyte : int) -> int {
+   rval : int = 0;
+   __asm__("mov @0, %ebx", fd);
+   __asm__("mov @0, %ecx", cbuf);
+   __asm__("mov @0, %edx", nbyte);
+   __asm__("mov $4, %eax");
+   __asm__("int $0x80");
+   __asm__("mov %eax, @0", rval);
+   return rval;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -898,7 +898,8 @@ void assemble_386(std::string path_str) {
 #ifdef __APPLE__
       std::cout << exec(std::string("ld " + _static + "-arch i386 -e __start  -macosx_version_min 10.10 -o ") + output_file + " " + out + " " + link_options) << std::endl;
 #else
-      std::cout << exec(std::string("ld " + _static + "-arch i386 -e __start -o ") + output_file + " " + out + " " + link_options) << std::endl;
+      std::cout << exec(std::string("ld " + _static + "-m elf_i386 -e __start -o ") + output_file + " " + out + " " + link_options) << std::endl;
+      // FIXME: don't hardcode the machine type
 #endif
       //remove(out.c_str());
    }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 
 
 #include <cstdio>
+#include <cstring>
 
 static void print_token(stb_lexer *lexer)
 {
@@ -777,11 +778,20 @@ static void generate_386(Scope &scope, std::ostream &os) {
    //os << ".data" << std::endl;
    //generate data section
    //os << ".text" << std::endl;
+#ifdef __APPLE__
    os << ".section __TEXT,__text,regular,pure_instructions" << std::endl;
+#else
+   // ELF. TODO: Windows PE?
+   os << ".text" << std::endl;
+#endif
    Gen_386 g386 = Gen_386(os);
    g386.gen_scope(scope);
    
+#ifdef __APPLE__
    os << ".section __TEXT,__cstring,cstring_literals" << std::endl;
+#else
+   os << ".section .rodata" << std::endl;
+#endif
    g386.gen_rodata();
 }
 
@@ -866,9 +876,17 @@ void assemble_386(std::string path_str) {
       if (output_file.compare("") == 0) {
          output_file = out;
       }
+#ifdef __APPLE__
       std::cout << exec(std::string("as -arch i386 -g -Q -o ") + output_file + " " + path_str) << std::endl;
+#else
+      std::cout << exec(std::string("as --32 -g -o ") + output_file + " " + path_str) << std::endl;
+#endif
    } else {
+#ifdef __APPLE__
       std::cout << exec(std::string("as -arch i386 -g -Q -o ") + out + " " + path_str) << std::endl;
+#else
+      std::cout << exec(std::string("as --32 -g -o ") + out + " " + path_str) << std::endl;
+#endif
       if (output_file.compare("") == 0) {
          output_file = out;
          output_file.replace(output_file.rfind(".o"), 2, "");
@@ -877,7 +895,11 @@ void assemble_386(std::string path_str) {
       if (link_options.size() == 0) {
          _static = "-static ";
       }
+#ifdef __APPLE__
       std::cout << exec(std::string("ld " + _static + "-arch i386 -e __start  -macosx_version_min 10.10 -o ") + output_file + " " + out + " " + link_options) << std::endl;
+#else
+      std::cout << exec(std::string("ld " + _static + "-arch i386 -e __start -o ") + output_file + " " + out + " " + link_options) << std::endl;
+#endif
       //remove(out.c_str());
    }
    //remove(path_str.c_str());

--- a/tests/IA_32_Linux.htn
+++ b/tests/IA_32_Linux.htn
@@ -1,0 +1,54 @@
+
+main : () -> void {
+
+   import "platform/linux/i386/_exit.htn";
+   import "platform/linux/i386/_write.htn";
+   import "platform/linux/i386/_open.htn";
+   import "platform/linux/i386/_close.htn";
+   
+   
+   O_RDONLY  : const int = 0x0000;
+   O_WRONLY  : const int = 0x0001;
+   O_RDWR    : const int = 0x0002;
+   O_ACCMODE : const int = 0x0003;
+   
+   O_CREATE  : const int = 0x0040;
+   
+   O_CLOEXEC : const int = 0x80000;
+   
+   stdout : const int = 1;
+   fmt_str : *char = "Hello World\n";
+   bit_ops : int = O_CREATE | O_CLOEXEC | O_RDWR;
+   fd : int = _open("test_file.txt", bit_ops, 0x0FFF);//RDRW user, system, groups file perms
+   _write(fd, "Hello Wosrld\n", 13);
+   _write(stdout, fmt_str, 12);
+   in : int = 10;
+   while (in < 10) {
+      _write(1, "test\n", 5);
+      ++in;
+   }
+   
+   _close(fd);
+   cdebug "main_test";
+   _exit(-1);
+   cdebug "main_test";
+}
+
+
+_start : plain () -> void {
+   __asm__("push %ebp");
+   __asm__("mov %esp, %ebp");
+   main();
+   cdebug "htn_ctr0_OSX_i386_start";
+   __asm__("add $8, %esp");
+   __asm__("pop %ebp");
+   __asm__("sub $8, %esp");
+   __asm__("mov $0, %eax");
+   __asm__("push %eax");
+   __asm__("mov $1, %eax");
+   __asm__("int $0x80");
+   cdebug "htn_ctr0_OSX_i386_start";
+   
+}
+
+cdebug "global";


### PR DESCRIPTION
IA_32_Linux works on my Ubuntu 14.04 (amd64) machine.
Yes, there should be a less kludgey way to abstract linker/executable file format differences. No, this commit doesn't bother with any of that. Ifdefs all the way.
